### PR TITLE
Support for multiple IPs in META field

### DIFF
--- a/rest_framework_sso/models.py
+++ b/rest_framework_sso/models.py
@@ -52,9 +52,9 @@ class SessionToken(models.Model):
 
     def update_attributes(self, request):
         if request.META.get("HTTP_X_FORWARDED_FOR"):
-            self.ip_address = request.META.get("HTTP_X_FORWARDED_FOR")
+            self.ip_address = request.META.get("HTTP_X_FORWARDED_FOR").split(",")[0].strip()
         elif request.META.get("REMOTE_ADDR"):
-            self.ip_address = request.META.get("REMOTE_ADDR")
+            self.ip_address = request.META.get("REMOTE_ADDR").split(",")[0].strip()
         else:
             self.ip_address = None
 


### PR DESCRIPTION
`HTTP_X_FORWARDED_FOR` and `REMOTE_ADDR` can have more than one IP in them (it can be a comma separated list, usually appended by some proxies from the client to the server) - if that is the case, then the saving of the model breaks with;

`DataError: invalid input syntax for type inet: "213.x.x.x, 10.0.0.x"` (IPs redacted) in `views.py` when you save the token.