### PR TITLE
Narrow SessionToken saves to mutated fields to preserve concurrent revocations

### DIFF
--- a/rest_framework_sso/utils.py
+++ b/rest_framework_sso/utils.py
@@ -153,10 +153,12 @@ def authenticate_payload(payload, request=None):
                 iat = payload.get(claims.ISSUED_AT)
                 if iat is None or iat < int(session_token.last_issued_at.timestamp()):
                     raise exceptions.AuthenticationFailed(_("Token has been superseded."))
+            update_fields = ["last_used_at"]
             if request is not None:
                 session_token.update_attributes(request=request)
+                update_fields += ["ip_address", "user_agent", "version"]
             session_token.last_used_at = timezone.now()
-            session_token.save()
+            session_token.save(update_fields=update_fields)
             user = session_token.user
         except SessionToken.DoesNotExist:
             raise exceptions.AuthenticationFailed(_("Invalid token."))

--- a/rest_framework_sso/views.py
+++ b/rest_framework_sso/views.py
@@ -84,7 +84,10 @@ class ObtainSessionTokenView(BaseAPIView):
         session_token.update_attributes(request=request)
         session_token.last_issued_at = timezone.now().replace(microsecond=0)
         payload = create_session_payload(session_token=session_token, user=user)
-        session_token.save()
+        if session_token._state.adding:
+            session_token.save()
+        else:
+            session_token.save(update_fields=["ip_address", "user_agent", "version", "last_issued_at"])
         jwt_token = encode_jwt_token(payload=payload)
         return Response({"token": jwt_token})
 
@@ -116,7 +119,10 @@ class ObtainAuthorizationTokenView(BaseAPIView):
                 session_token = SessionToken(user=request.user, created_by=request.user)
 
         session_token.update_attributes(request=request)
-        session_token.save()
+        if session_token._state.adding:
+            session_token.save()
+        else:
+            session_token.save(update_fields=["ip_address", "user_agent", "version"])
         payload = create_authorization_payload(
             session_token=session_token, user=request.user, **serializer.validated_data
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -119,6 +119,33 @@ def test_authenticate_rejects_payload_missing_iat(user):
 
 
 @pytest.mark.django_db
+def test_authenticate_does_not_unrevoke_concurrently_revoked_token(user, monkeypatch):
+    session_token = SessionToken.objects.create(user=user, created_by=user)
+    revoked_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    original_save = SessionToken.save
+
+    def save_after_concurrent_revocation(self, *args, **kwargs):
+        SessionToken.objects.filter(pk=self.pk).update(revoked_at=revoked_at)
+        return original_save(self, *args, **kwargs)
+
+    monkeypatch.setattr(SessionToken, "save", save_after_concurrent_revocation)
+    assert authenticate_payload(payload=_auth_payload(session_token, user)) == user
+    session_token.refresh_from_db()
+    assert session_token.revoked_at == revoked_at
+
+
+@pytest.mark.django_db
+def test_authenticate_persists_request_attributes_and_last_used_at(user, api_factory):
+    session_token = SessionToken.objects.create(user=user, created_by=user)
+    request = api_factory.get("/", HTTP_USER_AGENT="test-agent", REMOTE_ADDR="10.1.2.3")
+    assert authenticate_payload(payload=_auth_payload(session_token, user), request=request) == user
+    session_token.refresh_from_db()
+    assert session_token.ip_address == "10.1.2.3"
+    assert session_token.user_agent == "test-agent"
+    assert session_token.last_used_at is not None
+
+
+@pytest.mark.django_db
 def test_authenticate_skips_check_when_verify_disabled(user, monkeypatch):
     monkeypatch.setattr(api_settings, "VERIFY_TOKEN_ISSUED_AT", False)
     last = datetime(2026, 5, 13, 10, 0, 0, tzinfo=timezone.utc)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -59,6 +59,40 @@ def test_session_post_reuse_advances_last_issued_at(user, api_factory):
     assert second.last_issued_at == t2
 
 
+def _save_with_concurrent_revocation(revoked_at):
+    original_save = SessionToken.save
+
+    def save(self, *args, **kwargs):
+        SessionToken.objects.filter(pk=self.pk).update(revoked_at=revoked_at)
+        return original_save(self, *args, **kwargs)
+
+    return save
+
+
+@pytest.mark.django_db
+def test_session_post_does_not_unrevoke_concurrently_revoked_token(user, api_factory, monkeypatch):
+    session_token = SessionToken.objects.create(user=user, client_id="web", created_by=user)
+    revoked_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(SessionToken, "save", _save_with_concurrent_revocation(revoked_at))
+    response = _post_session(api_factory, {"username": "alice", "password": "pw", "client_id": "web"})
+    assert response.status_code == 200
+    session_token.refresh_from_db()
+    assert session_token.revoked_at == revoked_at
+
+
+@pytest.mark.django_db
+def test_authorization_post_does_not_unrevoke_concurrently_revoked_token(user, api_factory, monkeypatch):
+    session_token = SessionToken.objects.create(user=user, client_id="web", created_by=user)
+    revoked_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(SessionToken, "save", _save_with_concurrent_revocation(revoked_at))
+    request = api_factory.post("/authorize/", data={}, format="json")
+    force_authenticate(request, user=user, token={claims.SESSION_ID: str(session_token.pk)})
+    response = ObtainAuthorizationTokenView.as_view()(request)
+    assert response.status_code == 200
+    session_token.refresh_from_db()
+    assert session_token.revoked_at == revoked_at
+
+
 @pytest.mark.django_db
 def test_authorization_post_does_not_touch_last_issued_at(user, api_factory):
     original_last_issued_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
Fixes #33

## Problem

`utils.authenticate_payload` loaded the token via `SessionToken.objects.active().get(...)`, stamped `last_used_at` (and `ip_address`/`user_agent`/`version` via `update_attributes`), then called a bare `session_token.save()`. The in-memory instance still carried `revoked_at=None`, so a revocation landing in the DB between the SELECT and the save was silently overwritten — the token was un-revoked.

The review found the same pattern at the two other `save()` sites in the library: `ObtainSessionTokenView.post` and `ObtainAuthorizationTokenView.post`, where the resurrected session additionally received a freshly issued JWT.

## Fix

Save with `update_fields` limited to the fields each call site actually mutates:

- `authenticate_payload`: `last_used_at`, plus `ip_address`/`user_agent`/`version` only when a request was passed
- `ObtainSessionTokenView.post`: `ip_address`, `user_agent`, `version`, `last_issued_at` (full insert for new tokens, detected via `_state.adding` since the UUID pk is pre-assigned)
- `ObtainAuthorizationTokenView.post`: `ip_address`, `user_agent`, `version`

Side benefit: a concurrently deleted row now raises ("did not affect any rows") instead of Django's update-then-insert silently resurrecting it.

## Tests

- Race regression tests for all three sites: wrap `SessionToken.save` to inject a queryset-level revocation between the SELECT and the save, assert `revoked_at` survives in the DB. All three fail against the unfixed code.
- `test_authenticate_persists_request_attributes_and_last_used_at` guards the `update_fields` list completeness against future additions to `update_attributes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)